### PR TITLE
chore: release v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/philipcristiano/declare-schema/compare/v0.0.1...v0.0.2) - 2024-08-02
+
+### Fixed
+- *(deps)* update rust crate serde_json to v1.0.122
+- *(deps)* update rust crate clap to v4.5.13
+- *(deps)* update rust crate toml to v0.8.19
+- *(deps)* update rust crate toml to v0.8.18
+- *(deps)* update rust crate clap to v4.5.12
+- *(deps)* update rust crate toml to v0.8.17
+- *(deps)* update rust crate serde_json to v1.0.121
+- *(deps)* update rust crate tokio to v1.39.2
+- *(deps)* update rust crate toml to v0.8.16
+- *(deps)* update rust crate clap to v4.5.11
+- *(deps)* update rust crate sqlparser to 0.49.0
+- *(deps)* update rust crate tokio to v1.39.1
+- *(deps)* update rust crate clap to v4.5.10
+- *(deps)* update rust crate sqlx to 0.8.0
+- *(deps)* update rust crate toml to v0.8.15
+- *(deps)* update rust crate thiserror to v1.0.63
+- *(deps)* update rust crate tokio to v1.38.1
+- *(deps)* update rust crate thiserror to v1.0.62
+- *(deps)* update rust crate uuid to v1.10.0
+- *(deps)* update rust crate tokio to v1.38.0
+- *(deps)* update rust crate url to v2.5.2
+- *(deps)* update rust crate toml to v0.8.14
+- *(deps)* update rust crate serde_json to v1.0.120
+- Remove unneeded dep service_conventions
+
+### Other
+- *(deps)* lock file maintenance
+- *(deps)* update rust docker tag to v1.80
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* update rust docker tag to v1.79
+
 ## [0.0.1](https://github.com/philipcristiano/declare-schema/releases/tag/v0.0.1) - 2024-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "declare_schema"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declare_schema"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `declare_schema`: 0.0.1 -> 0.0.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/philipcristiano/declare-schema/compare/v0.0.1...v0.0.2) - 2024-08-02

### Fixed
- *(deps)* update rust crate serde_json to v1.0.122
- *(deps)* update rust crate clap to v4.5.13
- *(deps)* update rust crate toml to v0.8.19
- *(deps)* update rust crate toml to v0.8.18
- *(deps)* update rust crate clap to v4.5.12
- *(deps)* update rust crate toml to v0.8.17
- *(deps)* update rust crate serde_json to v1.0.121
- *(deps)* update rust crate tokio to v1.39.2
- *(deps)* update rust crate toml to v0.8.16
- *(deps)* update rust crate clap to v4.5.11
- *(deps)* update rust crate sqlparser to 0.49.0
- *(deps)* update rust crate tokio to v1.39.1
- *(deps)* update rust crate clap to v4.5.10
- *(deps)* update rust crate sqlx to 0.8.0
- *(deps)* update rust crate toml to v0.8.15
- *(deps)* update rust crate thiserror to v1.0.63
- *(deps)* update rust crate tokio to v1.38.1
- *(deps)* update rust crate thiserror to v1.0.62
- *(deps)* update rust crate uuid to v1.10.0
- *(deps)* update rust crate tokio to v1.38.0
- *(deps)* update rust crate url to v2.5.2
- *(deps)* update rust crate toml to v0.8.14
- *(deps)* update rust crate serde_json to v1.0.120
- Remove unneeded dep service_conventions

### Other
- *(deps)* lock file maintenance
- *(deps)* update rust docker tag to v1.80
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* update rust docker tag to v1.79
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).