### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/philipcristiano/declare-schema/compare/v0.0.5...v0.0.6) - 2024-10-23
+
+### Other
+
+- Remove cargo.lock
+- More tests against postgres
+- Test against Postgres
+- Update pg connect info
+- *(deps)* lock file maintenance
+- *(deps)* update rust docker tag to v1.82
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+
 ## [0.0.5](https://github.com/philipcristiano/declare-schema/compare/v0.0.4...v0.0.5) - 2024-10-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declare_schema"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `declare_schema`: 0.0.5 -> 0.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.6](https://github.com/philipcristiano/declare-schema/compare/v0.0.5...v0.0.6) - 2024-10-23

### Other

- Remove cargo.lock
- More tests against postgres
- Test against Postgres
- Update pg connect info
- *(deps)* lock file maintenance
- *(deps)* update rust docker tag to v1.82
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).