### PR TITLE
chore: release v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/philipcristiano/declare-schema/compare/v0.0.6...v0.0.7) - 2024-10-24
+
+### Fixed
+
+- Error if check cannot be changed
+- Start giving errors in migrations cannot be determined
+
 ## [0.0.6](https://github.com/philipcristiano/declare-schema/compare/v0.0.5...v0.0.6) - 2024-10-23
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declare_schema"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `declare_schema`: 0.0.6 -> 0.0.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.7](https://github.com/philipcristiano/declare-schema/compare/v0.0.6...v0.0.7) - 2024-10-24

### Fixed

- Error if check cannot be changed
- Start giving errors in migrations cannot be determined
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).