### PR TITLE
chore: release v0.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/philipcristiano/declare-schema/compare/v0.0.7...v0.0.8) - 2024-10-28
+
+### Added
+
+- Error on ALTER INDEX
+
+### Other
+
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+
 ## [0.0.7](https://github.com/philipcristiano/declare-schema/compare/v0.0.6...v0.0.7) - 2024-10-24
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declare_schema"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `declare_schema`: 0.0.7 -> 0.0.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.8](https://github.com/philipcristiano/declare-schema/compare/v0.0.7...v0.0.8) - 2024-10-28

### Added

- Error on ALTER INDEX

### Other

- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).