### PR TITLE
fix: Exclude .env from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"
 
+exclude = [".env"]
+
 [[bin]]
 name = "declare-schema"
 


### PR DESCRIPTION
sqlx will try to connect with it which complicates using this package as a lib