### PR TITLE
chore: release v0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9](https://github.com/philipcristiano/declare-schema/compare/v0.0.8...v0.0.9) - 2024-10-28
+
+### Fixed
+
+- Include from and to constraints
+- Exclude .env from package
+
 ## [0.0.8](https://github.com/philipcristiano/declare-schema/compare/v0.0.7...v0.0.8) - 2024-10-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declare_schema"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `declare_schema`: 0.0.8 -> 0.0.9 (⚠️ API breaking changes)

### ⚠️ `declare_schema` breaking changes

```
--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant MigrationError::CannotModifyTableConstraint in /tmp/.tmpPg0ezZ/declare-schema/src/lib.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.9](https://github.com/philipcristiano/declare-schema/compare/v0.0.8...v0.0.9) - 2024-10-28

### Fixed

- Include from and to constraints
- Exclude .env from package
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).