### PR TITLE
chore: release v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/philipcristiano/declare-schema/compare/v0.0.9...v0.0.10) - 2024-11-22
+
+### Fixed
+
+- *(deps)* update rust crate thiserror to v2
+- *(deps)* update rust crate sqlparser to 0.52.0 ([#110](https://github.com/philipcristiano/declare-schema/pull/110))
+
+### Other
+
+- *(deps)* lock file maintenance ([#113](https://github.com/philipcristiano/declare-schema/pull/113))
+- *(deps)* lock file maintenance ([#111](https://github.com/philipcristiano/declare-schema/pull/111))
+- *(deps)* lock file maintenance ([#108](https://github.com/philipcristiano/declare-schema/pull/108))
+- *(deps)* lock file maintenance
+- *(deps)* lock file maintenance
+- Start documentation
+
 ## [0.0.9](https://github.com/philipcristiano/declare-schema/compare/v0.0.8...v0.0.9) - 2024-10-28
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "declare_schema"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 description = "CLI / Library for Postgres schema migrations"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `declare_schema`: 0.0.9 -> 0.0.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.10](https://github.com/philipcristiano/declare-schema/compare/v0.0.9...v0.0.10) - 2024-11-22

### Fixed

- *(deps)* update rust crate thiserror to v2
- *(deps)* update rust crate sqlparser to 0.52.0 ([#110](https://github.com/philipcristiano/declare-schema/pull/110))

### Other

- *(deps)* lock file maintenance ([#113](https://github.com/philipcristiano/declare-schema/pull/113))
- *(deps)* lock file maintenance ([#111](https://github.com/philipcristiano/declare-schema/pull/111))
- *(deps)* lock file maintenance ([#108](https://github.com/philipcristiano/declare-schema/pull/108))
- *(deps)* lock file maintenance
- *(deps)* lock file maintenance
- Start documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).